### PR TITLE
Implement Live Preview & extend Reading Mode support

### DIFF
--- a/MarkdownSample.md
+++ b/MarkdownSample.md
@@ -1,0 +1,86 @@
+---
+frontmatter: test
+---
+multiple terms
+are not supported
+: plugin will always use the single line closest to the definition as the term.
+
+Paragraphs between definitions are left alone and not accidentally interpreted as a term.
+
+this is a definition term
+: this is a definition
+
+2024-07-17 01:57:06 PM
+: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam in diam consectetur dui volutpat sagittis pretium et odio. Maecenas accumsan quam ut tempor laoreet. Integer mattis fermentum metus a mollis. Fusce vulputate vulputate maximus. Maecenas volutpat porta aliquet. Morbi vehicula nunc nec lacus elementum egestas. Nullam aliquam bibendum ultricies. Mauris luctus hendrerit neque, id dictum eros pretium a. Suspendisse bibendum eros ut dui accumsan pellentesque. Phasellus ac neque non ante imperdiet efficitur ut sed odio. Praesent eleifend ac erat nec consequat. 
+
+This is an example term
+: this is the first definition
+
+: this is a definition on a new line. these will render as regular paragraphs, not definitions, in live preview or reading mode.
+
+this is a term
+  : with an indented definition... that's very long. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam in diam consectetur dui volutpat sagittis pretium et odio. Maecenas accumsan quam ut tempor laoreet. Integer mattis fermentum metus a mollis. Fusce vulputate vulputate maximus. Maecenas volutpat porta aliquet. Morbi vehicula nunc nec lacus elementum egestas. Nullam aliquam bibendum ultricies.
+  : Let's add another definition.
+  : and a third definition.
+
+_Italic Term_
+  : with an indented definition
+  : and another indented definition and _italic_ and **bold** and ==highlight== and [link](https://example.com)
+
+`Code Term`
+  ~ with a tilde for the definition marker and `inline code` and ~~strikethrough~~
+  ~ another definition and _italic_ and **bold** and ==highlight== and [link](https://example.com)
+
+[This is a linked term](https://example.com)
+: This is a definition for the linked term.
+
+> > Super nested
+> > : definition?
+> 
+> nested
+> : definition
+
+```
+Term
+: definition
+: another definition
+```
+
+### Invalid Definitions
+: definition rendering is not valid
+
+- this is a list
+: definition rendering is not valid
+
+0. this is a list
+: definition rendering is not valid
+
+![test|200](https://picsum.photos/200/100)
+: definition rendering is not valid
+
+---
+: definition rendering is not valid
+
+***
+: definition rendering is not valid
+
+___
+: definition rendering is not valid[^1]
+
+[^1]: this is a footnote
+: definition rendering is not valid
+
+| test         | table        |
+| ------------ | ------------ |
+| a table line | another word |
+: definition rendering is not valid
+
+$$
+math
+$$
+: definition rendering is not valid
+
+^block-id
+: definition rendering is not valid
+
+

--- a/README.md
+++ b/README.md
@@ -2,35 +2,52 @@
 
 This plugin adds HTML definition lists to Obsidian. It is in the very early stages of development, and quite a bit more is planned.
 
-At the moment only supports the reading view. It will support live preview in the future.
+It supports both reading view and live preview/source mode.
 
 ## Usage
 
-While definition lists are not part of the standard markdown definition, a number of varients have introduced it. This plugin has adopted the markup standard as described in the [Extended Syntax](https://www.markdownguide.org/extended-syntax/). The markup syntax looks like this.
+While definition lists are not part of the standard markdown definition, a number of varients have introduced it. This plugin has adopted the markup standard as described in the [Extended Syntax](https://www.markdownguide.org/extended-syntax/). It also implements a few features from [Pandoc's definition list spec](https://pandoc.org/MANUAL.html#definition-lists), specifically the support for tilde as a definition marker and definition lines indented with two spaces.
 
 ```
 First Term
-:First definition.
+: First definition.
+
 Second Term
-:Second definition
-:Alternate second definition.
-Third Term
-:Third definition
+~ Second definition
+~ Alternate second definition with _italics_ and [a link](https://example.com).
+
+Third Term, with _Italics_ and ==Highlighting==
+  : Third definition, indented
 ```
+
+Multiple definitions with line breaks between them are not fully supported. For example, the following is supported in Pandoc but will **not** render as 1 term with 2 definitions in reading mode. It does render in live preview, though.
+
+```
+This is an example term
+: this is the first definition
+
+: this is another definition.
+```
+
+### Unsupported Definition List Mark-up
+
+- Multi-line terms
+- Multi-line/paragraph definitions
+- Definition lists nested inside definitions
+- Ordered & unordered lists nested inside definitions
+
 ## Styling
 
-Because definition lists are not part of the standard Obsidian markup, they are not recognized by any of the available themes. This plugin adds a couple bits of simply styline, but you will likely have to use [CSS Snippits](https://help.obsidian.md/Extending+Obsidian/CSS+snippets) to style to match your themes.
+Because definition lists are not part of the standard Obsidian markup, they are not recognized by any of the available themes. This plugin adds a couple bits of simple styling, but you will likely have to use [CSS Snippits](https://help.obsidian.md/Extending+Obsidian/CSS+snippets) to style to match your themes.
 
 If you come up with some CSS that matches a popular theme please share it by creating a [Github Issue](https://github.com/shammond42/definition-list/issues) on this project. I would like to build a collection of CSS samples others can use.
 
 ## Future Work
 
-1. Support live preview mode
-2. Build a collection of sample CSS snippits
-3. Settings to account for common alternatives
-  -- dt's and dd's inline vs separate lines
-  -- support alternate syntax options
-4. Use eslint and improve code quality
+1. Build a collection of sample CSS snippits
+1. Settings to account for common alternatives
+    - dt's and dd's inline vs separate lines
+1. Use eslint and improve code quality
 
 ## Building from Source
 
@@ -38,13 +55,13 @@ Clone this repository inside the Obsidian Vault:
 
 ```
 $ cd .obsidian/plugins/
-$ git clone https://github.com/otaviocc/obsidian-microblog
+$ git clone https://github.com/shammond42/definition-list
 ```
 
 Resolve the plugin dependencies and build it:
 
 ```
-$ cd obsidian-microblog
+$ cd definition-list
 $ npm i
 $ npm run build
 ```

--- a/main.ts
+++ b/main.ts
@@ -1,14 +1,19 @@
 import { Plugin, MarkdownPostProcessor } from 'obsidian';
 import { EditorView, ViewUpdate, ViewPlugin, DecorationSet, Decoration } from '@codemirror/view';
-import { EditorSelection, RangeSetBuilder } from '@codemirror/state';
+import { RangeSetBuilder } from '@codemirror/state';
 
-// Helper function to check if the editor is in Live Preview mode
+// Constants for regex patterns and strings
+const CODE_BLOCK_DELIMITER = '```';
+const DEFINITION_REGEX = /^(\s*)([:~])\s/;
+const HEADING_REGEX = /^#+\s/;
+const LIST_ITEM_REGEX = /^\s*(\*|\+|-|\d+\.)\s/;
+const HORIZONTAL_RULE_REGEX = /^(-{3,}|\*{3,}|_{3,})/;
+
 function isLivePreview(view: EditorView): boolean {
     const editorEl = view.dom.closest('.markdown-source-view');
     return editorEl?.classList.contains('is-live-preview') ?? false;
 }
 
-// ViewPlugin for handling decorations in the editor (Live Preview)
 const definitionListPlugin = ViewPlugin.fromClass(class {
     decorations: DecorationSet;
 
@@ -16,113 +21,120 @@ const definitionListPlugin = ViewPlugin.fromClass(class {
         this.decorations = this.buildDecorations(view);
     }
 
-    update(update: ViewUpdate) {
+    update(update: ViewUpdate): void {
         if (update.docChanged || update.viewportChanged || update.selectionSet) {
             this.decorations = this.buildDecorations(update.view);
         }
     }
 
-    buildDecorations(view: EditorView) {
+    buildDecorations(view: EditorView): DecorationSet {
         if (!isLivePreview(view)) {
             return Decoration.none;
         }
-
+    
         const builder = new RangeSetBuilder<Decoration>();
         const doc = view.state.doc;
         const selection = view.state.selection;
-
+    
         let inCodeBlock = false;
-
+        let lastLineWasTerm = false;
+        let lastLineWasDefinition = false;
+    
+        function isNotTerm(content: string): boolean {
+            return (
+                HEADING_REGEX.test(content) ||
+                LIST_ITEM_REGEX.test(content) ||
+                content.startsWith('![') ||
+                HORIZONTAL_RULE_REGEX.test(content) ||
+                content.startsWith('[^') ||
+                content.startsWith('|') ||
+                content.startsWith('$$') ||
+                content.startsWith('^')
+            );
+        }
+    
         for (let i = 1; i <= doc.lines; i++) {
             const line = doc.line(i);
             const lineText = line.text;
-
-            // Check for code block delimiters
-            if (lineText.trim().startsWith('```')) {
+            const trimmedLineText = lineText.trim();
+    
+            if (trimmedLineText === CODE_BLOCK_DELIMITER) {
                 inCodeBlock = !inCodeBlock;
+                lastLineWasTerm = false;
+                lastLineWasDefinition = false;
                 continue;
             }
-
+    
             if (inCodeBlock) {
-                continue;  // Skip processing if we're inside a code block
+                lastLineWasTerm = false;
+                lastLineWasDefinition = false;
+                continue;
             }
-
-            const prevLine = i > 1 ? doc.line(i - 1).text : '';
+    
+            const definitionMatch = DEFINITION_REGEX.exec(lineText);
             const nextLine = i < doc.lines ? doc.line(i + 1).text : '';
-
-            // Check if the line is part of a blockquote
-            const blockquoteMatch = lineText.match(/^(\s*>\s*)/);
-            const blockquotePrefix = blockquoteMatch ? blockquoteMatch[1] : '';
-
-            // Remove blockquote prefix for definition matching
-            const contentWithoutBlockquote = lineText.slice(blockquotePrefix.length);
-
-            const definitionMatch = contentWithoutBlockquote.match(/^(\s{0,2})([:~])\s/);
-            const isPrevLineHeading = prevLine.startsWith('#');
-            const isNextLineDefinition = nextLine.slice(blockquotePrefix.length).match(/^(\s{0,2})([:~])\s/);
-            const isListItem = contentWithoutBlockquote.match(/^\s*(-|\d+\.)\s/);
-            const isPrevLineListItem = prevLine.slice(blockquotePrefix.length).match(/^\s*(-|\d+\.)\s/);
-
-            if (definitionMatch && !isPrevLineHeading && !isPrevLineListItem) {
-                const [fullMatch, indent, marker] = definitionMatch;
+            const isNextLineDefinition = DEFINITION_REGEX.test(nextLine.trim());
+    
+            if (trimmedLineText === '') {
+                // Reset the state when encountering a blank line
+                lastLineWasTerm = false;
+                lastLineWasDefinition = false;
+            } else if (definitionMatch && (lastLineWasTerm || lastLineWasDefinition)) {
+                const [, indent, marker] = definitionMatch;
                 const isIndented = indent.length > 0;
-                const indentStartPos = line.from + blockquotePrefix.length;
-                const indentEndPos = indentStartPos + indent.length;
-                const markerStartPos = indentEndPos;
-                const markerEndPos = indentStartPos + fullMatch.length;
-
-                const isCursorTouchingIndent = this.isCursorTouching(selection, indentStartPos, indentEndPos);
-                const isCursorBetweenIndentAndMarker = this.isCursorTouching(selection, indentEndPos, markerStartPos);
-                const isCursorTouchingMarker = this.isCursorTouching(selection, markerStartPos, markerEndPos);
-
-                if (isIndented) {
-                    if (isCursorTouchingIndent || isCursorBetweenIndentAndMarker || isCursorTouchingMarker) {
-                        // Apply dd-margin to indent spaces
-                        builder.add(indentStartPos, indentEndPos, Decoration.mark({class: "definition-list-dd-margin"}));
-                    }
-
-                    if (isCursorTouchingIndent || isCursorBetweenIndentAndMarker || isCursorTouchingMarker) {
-                        // Apply dd-content to marker
-                        builder.add(markerStartPos, markerEndPos, Decoration.mark({class: "definition-list-dd-content"}));
-                    } else {
-                        // Hide marker if cursor is not touching or between
-                        builder.add(markerStartPos, markerEndPos, Decoration.mark({class: "definition-list-hidden-marker"}));
-                        // Add margin to first visible content after marker
-                        builder.add(markerEndPos, markerEndPos + 1, Decoration.mark({class: "definition-list-dd-margin"}));
-                    }
-                } else {
-                    // Non-indented definition handling
-                    if (isCursorTouchingMarker) {
-                        builder.add(markerStartPos, markerEndPos, Decoration.mark({class: "definition-list-dd-margin"}));
-                    } else {
-                        builder.add(markerStartPos, markerEndPos, Decoration.mark({class: "definition-list-hidden-marker"}));
-                        builder.add(markerEndPos, markerEndPos + 1, Decoration.mark({class: "definition-list-dd-margin"}));
-                    }
-                }
-                
-                // Mark the rest of the definition (dd) line content
-                if (markerEndPos < line.to) {
-                    builder.add(markerEndPos, line.to, Decoration.mark({class: "definition-list-dd-content"}));
-                }
-            } else if (isNextLineDefinition && !contentWithoutBlockquote.startsWith('#') && !isListItem) {
+    
+                // Add line decoration for the whole definition
+                builder.add(
+                    line.from,
+                    line.from,
+                    Decoration.line({
+                        attributes: { class: isIndented ? "dl-dd-indent" : "dl-dd-reg" }
+                    })
+                );
+    
+                // Add mark decoration for the indentation + definition mark
+                const indentStartPos = line.from;
+                const markerEndPos = indentStartPos + indent.length + marker.length + 1;
+    
+                const isCursorTouchingIndentOrMarker = selection.ranges.some(range => 
+                    range.from <= markerEndPos && range.to >= indentStartPos
+                );
+    
+                builder.add(
+                    indentStartPos,
+                    markerEndPos,
+                    Decoration.mark({
+                        attributes: { class: isCursorTouchingIndentOrMarker ? "dl-marker" : "dl-hidden-marker" }
+                    })
+                );
+    
+                lastLineWasDefinition = true;
+                lastLineWasTerm = false;
+            } else if (isNextLineDefinition && !isNotTerm(trimmedLineText)) {
                 // This is a term (dt) line
-                builder.add(line.from + blockquotePrefix.length, line.to, Decoration.mark({class: "definition-list-dt"}));
+                builder.add(
+                    line.from,
+                    line.from,
+                    Decoration.line({
+                        attributes: { class: "dl-dt" }
+                    })
+                );
+                lastLineWasTerm = true;
+                lastLineWasDefinition = false;
+            } else {
+                lastLineWasTerm = false;
+                lastLineWasDefinition = false;
             }
         }
-
+    
         return builder.finish();
-    }
-
-    // Helper method to check if the cursor is touching a given range
-    isCursorTouching(selection: EditorSelection, from: number, to: number): boolean {
-        return selection.ranges.some(range => range.from <= to && range.to >= from);
     }
 }, {
     decorations: v => v.decorations
 });
 
 export default class DefinitionListPlugin extends Plugin {
-    async onload() {
+    async onload(): Promise<void> {
         // Register the post processor for reading mode
         this.registerMarkdownPostProcessor(this.definitionListPostProcessor);
 
@@ -131,71 +143,89 @@ export default class DefinitionListPlugin extends Plugin {
     }
 
     // Post-processor for handling definition lists in reading mode
-    definitionListPostProcessor: MarkdownPostProcessor = (element, context) => {
+    definitionListPostProcessor: MarkdownPostProcessor = (element: HTMLElement): void => {
+        function isNotTerm(content: string): boolean {
+            return (
+                content.match(/^#+\s/) !== null || // Heading
+                content.match(/^\s*(-|\d+\.)\s/) !== null || // List item
+                content.startsWith('>') || // Blockquote
+                content.startsWith('<img') || // Image
+                content.match(/^(-{3,}|\*{3,}|_{3,})/) !== null || // Horizontal rule
+                content.startsWith('[^') || // Footnote
+                content.includes('class="footnote-backref footnote-link"') || // Footnote backref
+                content.startsWith('|') || // Table
+                content.startsWith('$$') || // Math block
+                content.startsWith('^') // Link reference
+            );
+        }
+    
         const paragraphs = element.querySelectorAll("p");
-
+    
         paragraphs.forEach((paragraph) => {
             const lines = paragraph.innerHTML.split('<br>');
             let dl: HTMLDListElement | null = null;
             let currentTerm: string | null = null;
-            let isDefinitionList = false;
-            let skipNextLine = false;
-
+            let newContent: (HTMLElement | string)[] = [];
+            let invalidateCurrentPair = false;
+    
             for (let i = 0; i < lines.length; i++) {
                 const line = lines[i].trim();
                 const nextLine = i < lines.length - 1 ? lines[i + 1].trim() : '';
-                const definitionMatch = line.match(/^([:~])\s(.+)/);
-                const indentedDefinitionMatch = line.match(/^\s{1,2}([:~])\s(.+)/);
-
-                if (skipNextLine) {
-                    skipNextLine = false;
-                    continue;
-                }
-
-                if ((definitionMatch || indentedDefinitionMatch) && isDefinitionList) {
-                    if (!dl) {
-                        dl = document.createElement('dl');
+                const definitionMatch = line.match(/^(\s*)([:~])\s(.+)/);
+                const isNextLineDefinition = nextLine.match(/^(\s*)([:~])\s(.+)/);
+    
+    
+                if (definitionMatch && !invalidateCurrentPair) {
+                    if (definitionMatch[3].includes('class="footnote-backref footnote-link"')) {
+                        invalidateCurrentPair = true;
                     }
-
-                    if (currentTerm) {
-                        const dt = document.createElement('dt');
-                        dt.innerHTML = currentTerm;
-                        dl.appendChild(dt);
+                    
+                    if (currentTerm && !invalidateCurrentPair) {
+                        if (!dl) {
+                            dl = document.createElement('dl');
+                            newContent.push(dl);
+                            const dt = document.createElement('dt');
+                            dt.innerHTML = currentTerm;
+                            dl.appendChild(dt);
+                        }
+                        const dd = document.createElement('dd');
+                        dd.innerHTML = definitionMatch[3];
+                        dl.appendChild(dd);
+                    } else {
+                        if (currentTerm) {
+                            newContent.push(currentTerm + '<br>');
+                        }
+                        newContent.push(line + '<br>');
                         currentTerm = null;
+                        invalidateCurrentPair = false;
                     }
-
-                    const dd = document.createElement('dd');
-                    dd.innerHTML = (definitionMatch ? definitionMatch[2] : indentedDefinitionMatch![2]);
-                    dl.appendChild(dd);
-                } else if ((nextLine.match(/^[:~]\s/) || nextLine.match(/^\s{1,2}[:~]\s/)) && !line.match(/^#+\s/)) {
-                    // This line is a term, but not if it's a heading
+                } else if (isNextLineDefinition && !isNotTerm(line) && !invalidateCurrentPair) {
                     if (currentTerm) {
-                        // If there's a previous term, add it to the list
-                        const dt = document.createElement('dt');
-                        dt.innerHTML = currentTerm;
-                        dl!.appendChild(dt);
+                        newContent.push(currentTerm + '<br>');
                     }
                     currentTerm = line;
-                    isDefinitionList = true;
-                } else if (isDefinitionList) {
-                    // End of definition list
+                    dl = null;
+                } else {
                     if (currentTerm) {
-                        const dt = document.createElement('dt');
-                        dt.innerHTML = currentTerm;
-                        dl!.appendChild(dt);
+                        newContent.push(currentTerm + '<br>');
                         currentTerm = null;
                     }
-                    isDefinitionList = false;
-                } else if (line.match(/^#+\s/)) {
-                    // If it's a heading, skip the next line to avoid parsing it as a definition
-                    skipNextLine = true;
+                    newContent.push(line + '<br>');
+                    dl = null;
+                    invalidateCurrentPair = false;
                 }
+    
             }
 
-            if (dl && dl.childNodes.length > 0) {
-                // Replace the paragraph with the definition list
-                paragraph.replaceWith(dl);
-            }
+            paragraph.innerHTML = '';
+            newContent.forEach(content => {
+                if (typeof content === 'string') {
+                    paragraph.innerHTML += content;
+                } else {
+                    paragraph.appendChild(content);
+                }
+            });
+    
         });
     };
 

--- a/main.ts
+++ b/main.ts
@@ -1,41 +1,205 @@
-import { Plugin } from 'obsidian';
+import { Plugin, MarkdownPostProcessor } from 'obsidian';
+import { EditorView, ViewUpdate, ViewPlugin, DecorationSet, Decoration } from '@codemirror/view';
+import { EditorSelection, RangeSetBuilder } from '@codemirror/state';
 
-
-export default class DefinitionListPlugin extends Plugin {
-	async onload() {
-		this.registerMarkdownPostProcessor((element, context) => {
-      const paragraphs = element.findAll("p");
-
-			for (let paragraph of paragraphs) {
-				const lines = paragraph.innerText.split('\n');
-
-				let definitionList;
-				if(lines[1][0] === ':') { // Check to see if second line start with a colon
-					definitionList = paragraph.createEl("dl");
-				} else { //Not a definition list
-					return;
-				}
-
-				for(let i=0; i<lines.length; i++) {
-					const line = lines[i];
-
-					const length = line.endsWith("<br>") ? line.length-4 : line.length;
-					if(line[0] === ':') {
-						const definition = line.substring(1, length).trim();
-						definitionList.createEl("dd", {text: definition});
-					} else {
-						const term = line.substring(0, length).trim();
-						definitionList.createEl("dt", {text: term});
-					}
-				}
-
-				paragraph.replaceWith(definitionList);
-			}
-    });
-	}
-
-	onunload() {
-		// Placeholder
-	}
+// Helper function to check if the editor is in Live Preview mode
+function isLivePreview(view: EditorView): boolean {
+    const editorEl = view.dom.closest('.markdown-source-view');
+    return editorEl?.classList.contains('is-live-preview') ?? false;
 }
 
+// ViewPlugin for handling decorations in the editor (Live Preview)
+const definitionListPlugin = ViewPlugin.fromClass(class {
+    decorations: DecorationSet;
+
+    constructor(view: EditorView) {
+        this.decorations = this.buildDecorations(view);
+    }
+
+    update(update: ViewUpdate) {
+        if (update.docChanged || update.viewportChanged || update.selectionSet) {
+            this.decorations = this.buildDecorations(update.view);
+        }
+    }
+
+    buildDecorations(view: EditorView) {
+        if (!isLivePreview(view)) {
+            return Decoration.none;
+        }
+
+        const builder = new RangeSetBuilder<Decoration>();
+        const doc = view.state.doc;
+        const selection = view.state.selection;
+
+        let inCodeBlock = false;
+
+        for (let i = 1; i <= doc.lines; i++) {
+            const line = doc.line(i);
+            const lineText = line.text;
+
+            // Check for code block delimiters
+            if (lineText.trim().startsWith('```')) {
+                inCodeBlock = !inCodeBlock;
+                continue;
+            }
+
+            if (inCodeBlock) {
+                continue;  // Skip processing if we're inside a code block
+            }
+
+            const prevLine = i > 1 ? doc.line(i - 1).text : '';
+            const nextLine = i < doc.lines ? doc.line(i + 1).text : '';
+
+            // Check if the line is part of a blockquote
+            const blockquoteMatch = lineText.match(/^(\s*>\s*)/);
+            const blockquotePrefix = blockquoteMatch ? blockquoteMatch[1] : '';
+
+            // Remove blockquote prefix for definition matching
+            const contentWithoutBlockquote = lineText.slice(blockquotePrefix.length);
+
+            const definitionMatch = contentWithoutBlockquote.match(/^(\s{0,2})([:~])\s/);
+            const isPrevLineHeading = prevLine.startsWith('#');
+            const isNextLineDefinition = nextLine.slice(blockquotePrefix.length).match(/^(\s{0,2})([:~])\s/);
+            const isListItem = contentWithoutBlockquote.match(/^\s*(-|\d+\.)\s/);
+            const isPrevLineListItem = prevLine.slice(blockquotePrefix.length).match(/^\s*(-|\d+\.)\s/);
+
+            if (definitionMatch && !isPrevLineHeading && !isPrevLineListItem) {
+                const [fullMatch, indent, marker] = definitionMatch;
+                const isIndented = indent.length > 0;
+                const indentStartPos = line.from + blockquotePrefix.length;
+                const indentEndPos = indentStartPos + indent.length;
+                const markerStartPos = indentEndPos;
+                const markerEndPos = indentStartPos + fullMatch.length;
+
+                const isCursorTouchingIndent = this.isCursorTouching(selection, indentStartPos, indentEndPos);
+                const isCursorBetweenIndentAndMarker = this.isCursorTouching(selection, indentEndPos, markerStartPos);
+                const isCursorTouchingMarker = this.isCursorTouching(selection, markerStartPos, markerEndPos);
+
+                if (isIndented) {
+                    if (isCursorTouchingIndent || isCursorBetweenIndentAndMarker || isCursorTouchingMarker) {
+                        // Apply dd-margin to indent spaces
+                        builder.add(indentStartPos, indentEndPos, Decoration.mark({class: "definition-list-dd-margin"}));
+                    }
+
+                    if (isCursorTouchingIndent || isCursorBetweenIndentAndMarker || isCursorTouchingMarker) {
+                        // Apply dd-content to marker
+                        builder.add(markerStartPos, markerEndPos, Decoration.mark({class: "definition-list-dd-content"}));
+                    } else {
+                        // Hide marker if cursor is not touching or between
+                        builder.add(markerStartPos, markerEndPos, Decoration.mark({class: "definition-list-hidden-marker"}));
+                        // Add margin to first visible content after marker
+                        builder.add(markerEndPos, markerEndPos + 1, Decoration.mark({class: "definition-list-dd-margin"}));
+                    }
+                } else {
+                    // Non-indented definition handling
+                    if (isCursorTouchingMarker) {
+                        builder.add(markerStartPos, markerEndPos, Decoration.mark({class: "definition-list-dd-margin"}));
+                    } else {
+                        builder.add(markerStartPos, markerEndPos, Decoration.mark({class: "definition-list-hidden-marker"}));
+                        builder.add(markerEndPos, markerEndPos + 1, Decoration.mark({class: "definition-list-dd-margin"}));
+                    }
+                }
+                
+                // Mark the rest of the definition (dd) line content
+                if (markerEndPos < line.to) {
+                    builder.add(markerEndPos, line.to, Decoration.mark({class: "definition-list-dd-content"}));
+                }
+            } else if (isNextLineDefinition && !contentWithoutBlockquote.startsWith('#') && !isListItem) {
+                // This is a term (dt) line
+                builder.add(line.from + blockquotePrefix.length, line.to, Decoration.mark({class: "definition-list-dt"}));
+            }
+        }
+
+        return builder.finish();
+    }
+
+    // Helper method to check if the cursor is touching a given range
+    isCursorTouching(selection: EditorSelection, from: number, to: number): boolean {
+        return selection.ranges.some(range => range.from <= to && range.to >= from);
+    }
+}, {
+    decorations: v => v.decorations
+});
+
+export default class DefinitionListPlugin extends Plugin {
+    async onload() {
+        // Register the post processor for reading mode
+        this.registerMarkdownPostProcessor(this.definitionListPostProcessor);
+
+        // Register the editor extension for live preview mode
+        this.registerEditorExtension(definitionListPlugin);
+    }
+
+    // Post-processor for handling definition lists in reading mode
+    definitionListPostProcessor: MarkdownPostProcessor = (element, context) => {
+        const paragraphs = element.querySelectorAll("p");
+
+        paragraphs.forEach((paragraph) => {
+            const lines = paragraph.innerHTML.split('<br>');
+            let dl: HTMLDListElement | null = null;
+            let currentTerm: string | null = null;
+            let isDefinitionList = false;
+            let skipNextLine = false;
+
+            for (let i = 0; i < lines.length; i++) {
+                const line = lines[i].trim();
+                const nextLine = i < lines.length - 1 ? lines[i + 1].trim() : '';
+                const definitionMatch = line.match(/^([:~])\s(.+)/);
+                const indentedDefinitionMatch = line.match(/^\s{1,2}([:~])\s(.+)/);
+
+                if (skipNextLine) {
+                    skipNextLine = false;
+                    continue;
+                }
+
+                if ((definitionMatch || indentedDefinitionMatch) && isDefinitionList) {
+                    if (!dl) {
+                        dl = document.createElement('dl');
+                    }
+
+                    if (currentTerm) {
+                        const dt = document.createElement('dt');
+                        dt.innerHTML = currentTerm;
+                        dl.appendChild(dt);
+                        currentTerm = null;
+                    }
+
+                    const dd = document.createElement('dd');
+                    dd.innerHTML = (definitionMatch ? definitionMatch[2] : indentedDefinitionMatch![2]);
+                    dl.appendChild(dd);
+                } else if ((nextLine.match(/^[:~]\s/) || nextLine.match(/^\s{1,2}[:~]\s/)) && !line.match(/^#+\s/)) {
+                    // This line is a term, but not if it's a heading
+                    if (currentTerm) {
+                        // If there's a previous term, add it to the list
+                        const dt = document.createElement('dt');
+                        dt.innerHTML = currentTerm;
+                        dl!.appendChild(dt);
+                    }
+                    currentTerm = line;
+                    isDefinitionList = true;
+                } else if (isDefinitionList) {
+                    // End of definition list
+                    if (currentTerm) {
+                        const dt = document.createElement('dt');
+                        dt.innerHTML = currentTerm;
+                        dl!.appendChild(dt);
+                        currentTerm = null;
+                    }
+                    isDefinitionList = false;
+                } else if (line.match(/^#+\s/)) {
+                    // If it's a heading, skip the next line to avoid parsing it as a definition
+                    skipNextLine = true;
+                }
+            }
+
+            if (dl && dl.childNodes.length > 0) {
+                // Replace the paragraph with the definition list
+                paragraph.replaceWith(dl);
+            }
+        });
+    };
+
+    onunload() {
+        // Placeholder
+    }
+}

--- a/styles.css
+++ b/styles.css
@@ -1,12 +1,23 @@
-/*
-
-This CSS file will be included with your plugin, and
-available in the app when your plugin is enabled.
-
-If your plugin does not need CSS, delete this file.
-
-*/
-
 dl dt {
   font-weight: bold;
+}
+
+.definition-list-dt {
+  font-weight: bold;
+}
+
+.definition-list-dd-margin {
+  display: inline-block;
+  margin-inline-start: 40px; /* Adjust as needed */
+}
+
+.definition-list-dd-content {
+  display: inline;
+}
+
+.definition-list-hidden-marker {
+  display: inline-block;
+  overflow: hidden;
+  height: 0;
+  width: 0;
 }

--- a/styles.css
+++ b/styles.css
@@ -1,21 +1,31 @@
+/* reading mode */
 dl dt {
   font-weight: bold;
 }
 
-.definition-list-dt {
+/* live preview */
+.dl-dt {
   font-weight: bold;
 }
 
-.definition-list-dd-margin {
+.dl-dd-reg {
   display: inline-block;
-  margin-inline-start: 40px; /* Adjust as needed */
+  width: calc(100% - 40px);
+  padding-left: 40px !important;
+  /* to add space between definitions, must use padding */
+  /* padding-bottom: 0.75em !important; */
 }
 
-.definition-list-dd-content {
-  display: inline;
+.dl-dd-indent {
+  display: inline-block;
+  width: calc(100% - 40px);
+  padding-left: 40px !important;
+  text-indent: 0px !important;
+  /* to add space between definitions, must use padding */
+  /* padding-bottom: 0.75em !important; */
 }
 
-.definition-list-hidden-marker {
+.dl-hidden-marker {
   display: inline-block;
   overflow: hidden;
   height: 0;


### PR DESCRIPTION
Hello! I've updated the plugin to support Live Preview and extended the Reading Mode support in a variety of cases. I also updated the Readme to cover the implemented features.

Quite frankly, I don't know anything about extending CodeMirror and all of this code is from genAI (Claude 3.5 Sonnet). However, I thoroughly tested it for functionality and as many edge cases as I could find. I believe it's in a very solid place and will be using this in my own vault.

### Features Implemented / Edge Cases Handled

- Both `:` and `~` are implemented as definition markers.
- Definitions indented by two spaces are recognized and rendered in reading mode & live preview.
- Complex in-line markdown renders properly within both terms and definitions in reading mode & live preview, including URLs, bold, italics, links, highlighting, etc.
- Definition lists are supported within 1 layer of block quotes in live preview and any level of block quoting in reading mode.
    - A future enhancement could be to support DLs being nested within any level of block quoting in live preview?
- Multi-definition terms, w/ definitions on neighboring lines (no blank space separating the definitions) are rendered, in reading mode & live preview.
- Code blocks properly do not render definition lists, in reading mode & live preview.
- When a line of text begins with a definition marker and is immediately underneath headers, ordered list items, and unordered list items, the line of text is rendered as plain text and not a definition, in reading mode & live preview.
- Cursor movement through terms & definitions in live preview is visually smooth, with no jumping around of the cursor, flashing styling, or other visual glitches.
- Indented definitions are not visually rendered differently from non-indented definitions (no accidental slight offset due to spaces)

### Not Implemented

- I couldn't get any syntax that has a full blank line between a term, definition, or other markdown element to work in reading mode; probably because of my lack of understanding about adding onto CodeMirror/Obsidian.
    - minor edge case: currently any line beginning with a definition marker (`:`, `~`) and a space after it are rendered as a definition in live preview, so multi-line definitions do render in reading mode. honestly feel like this is more like a bug though...
- Limiting terms to a single line seemed reasonable, so multi-line terms are not supported.
- Nested definition lists are not implemented.
- Lists nested inside definitions are not implemented.

### Test Markdown Sample

```
This is an example term
: this is the first definition

: this is another definition. this is rendered in live preview as a definition but not in reading mode. bit of a bug?

_Italic Term_
  : with an indented definition
  : and another indented definition and _italic_ and **bold** and ==highlight== and [link](https://example.com)

`Code Term`
  ~ with a tilde for the definition marker and `inline code` and ~~strikethrough~~
  ~ another definition and _italic_ and **bold** and ==highlight== and [link](https://example.com)

[This is a linked term](https://example.com)
: This is a definition for the linked term.

##### headings shouldn't be terms
: so the definition rendering doesn't display.

> > Super nested
> > : definition?
> 
> nested
> : definition
```