### PR TITLE
Update styles.css to:

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3,24 +3,24 @@ dl dt {
   font-weight: bold;
 }
 
+dl dd P
+	margin-inline-start: var(--list-indent);
+
 /* live preview */
 .dl-dt {
   font-weight: bold;
 }
 
-.dl-dd-reg {
-  display: inline-block;
-  width: calc(100% - 40px);
-  padding-left: 40px !important;
+.markdown-source-view.mod-cm6 .cm-line.dl-dd-reg,
+.markdown-source-view.mod-cm6 .cm-line.dl-dd-indent
+{
+  padding-inline-start: var(--list-indent);
   /* to add space between definitions, must use padding */
   /* padding-bottom: 0.75em !important; */
 }
 
-.dl-dd-indent {
-  display: inline-block;
-  width: calc(100% - 40px);
-  padding-left: 40px !important;
-  text-indent: 0px !important;
+.markdown-source-view.mod-cm6 .cm-line.dl-dd-indent {
+  text-indent: 0px;
   /* to add space between definitions, must use padding */
   /* padding-bottom: 0.75em !important; */
 }

--- a/styles.css
+++ b/styles.css
@@ -1,33 +1,29 @@
 /* reading mode */
 dl dt {
   font-weight: bold;
+  padding-block-start: var(--list-spacing);
 }
 
-dl dd P
-	margin-inline-start: var(--list-indent);
+dd {
+  margin-inline-start: var(--list-indent);
+  padding-block-end: var(--list-spacing);
+}
 
 /* live preview */
 .dl-dt {
   font-weight: bold;
+  padding-block-start: var(--list-spacing);
 }
 
-.markdown-source-view.mod-cm6 .cm-line.dl-dd-reg,
-.markdown-source-view.mod-cm6 .cm-line.dl-dd-indent
-{
-  padding-inline-start: var(--list-indent);
-  /* to add space between definitions, must use padding */
-  /* padding-bottom: 0.75em !important; */
+.markdown-source-view.mod-cm6 .cm-line.dl-dd-reg, .markdown-source-view.mod-cm6 .cm-line.dl-dd-indent {
+  padding-inline-start: var(--list-indent-editing);
+  padding-block-end: var(--list-spacing); /* to add space between definitions, must use padding */
 }
 
 .markdown-source-view.mod-cm6 .cm-line.dl-dd-indent {
-  text-indent: 0px;
-  /* to add space between definitions, must use padding */
-  /* padding-bottom: 0.75em !important; */
+  text-indent: 0;
 }
 
 .dl-hidden-marker {
-  display: inline-block;
-  overflow: hidden;
-  height: 0;
-  width: 0;
+  display: none;
 }


### PR DESCRIPTION
- update the specificity to remove the need for "!important" CSS flags that could cause issues down the line (https://docs.obsidian.md/Themes/App+themes/Theme+guidelines#Avoid+%60!important%60+declarations)
- replace `padding-left` with `padding-inline-start` to make styling more resilient for left-to-right and right-to-left changes
- replace the padding values with built-in obsidian CSS variables that control list indent sizes